### PR TITLE
Fix remaining compiler warnings

### DIFF
--- a/pTk/mTk/Tktable/tkTable.c
+++ b/pTk/mTk/Tktable/tkTable.c
@@ -1909,7 +1909,7 @@ TableDisplay(ClientData clientdata)
 	     * let's see if we have the value cached already
 	     * if not, run the findColTag routine and cache the value
 	     */
-	    entryPtr = Tcl_CreateHashEntry(colTagsCache, (char *)ucol, &new);
+	    entryPtr = Tcl_CreateHashEntry(colTagsCache, INT2PTR(ucol), &new);
 	    if (new) {
 		colPtr = FindRowColTag(tablePtr, ucol, COL);
 		Tcl_SetHashValue(entryPtr, colPtr);
@@ -2521,7 +2521,7 @@ TableFlashEvent(ClientData clientdata)
     entries = 0;
     for (entryPtr = Tcl_FirstHashEntry(tablePtr->flashCells, &search);
 	 entryPtr != NULL; entryPtr = Tcl_NextHashEntry(&search)) {
-	count = (int) Tcl_GetHashValue(entryPtr);
+	count = PTR2INT(Tcl_GetHashValue(entryPtr));
 	if (--count <= 0) {
 	    /* get the cell address and invalidate that region only */
 	    TableParseArrayIndex(&row, &col,
@@ -2533,7 +2533,7 @@ TableFlashEvent(ClientData clientdata)
 	    TableRefresh(tablePtr, row-tablePtr->rowOffset,
 		    col-tablePtr->colOffset, CELL);
 	} else {
-	    Tcl_SetHashValue(entryPtr, (ClientData) count);
+	    Tcl_SetHashValue(entryPtr, INT2PTR(count));
 	    entries++;
 	}
     }
@@ -2578,7 +2578,7 @@ TableAddFlash(Table *tablePtr, int row, int col)
 
     /* add the flash to the hash table */
     entryPtr = Tcl_CreateHashEntry(tablePtr->flashCells, buf, &dummy);
-    Tcl_SetHashValue(entryPtr, tablePtr->flashTime);
+    Tcl_SetHashValue(entryPtr, INT2PTR(tablePtr->flashTime));
 
     /* now set the timer if it's not already going and invalidate the area */
     if (tablePtr->flashTimer == NULL) {
@@ -2975,13 +2975,13 @@ TableAdjustParams(register Table *tablePtr)
     numPixels = 0;
     unpreset = 0;
     for (i = 0; i < tablePtr->cols; i++) {
-	entryPtr = Tcl_FindHashEntry(tablePtr->colWidths, (char *) i);
+	entryPtr = Tcl_FindHashEntry(tablePtr->colWidths, INT2PTR(i));
 	if (entryPtr == NULL) {
 	    tablePtr->colPixels[i] = -1;
 	    unpreset++;
 	    lastUnpreset = i;
 	} else {
-	    value = (int) Tcl_GetHashValue(entryPtr);
+	    value = PTR2INT(Tcl_GetHashValue(entryPtr));
 	    if (value > 0) {
 		tablePtr->colPixels[i] = value * tablePtr->charWidth + px;
 	    } else {
@@ -3069,13 +3069,13 @@ TableAdjustParams(register Table *tablePtr)
 	numPixels	= 0;
 	unpreset	= 0;
 	for (i = 0; i < tablePtr->rows; i++) {
-	    entryPtr = Tcl_FindHashEntry(tablePtr->rowHeights, (char *) i);
+	    entryPtr = Tcl_FindHashEntry(tablePtr->rowHeights, INT2PTR(i));
 	    if (entryPtr == NULL) {
 		tablePtr->rowPixels[i] = -1;
 		unpreset++;
 		lastUnpreset = i;
 	    } else {
-		value = (int) Tcl_GetHashValue(entryPtr);
+		value = PTR2INT(Tcl_GetHashValue(entryPtr));
 		if (value > 0) {
 		    tablePtr->rowPixels[i] = value * tablePtr->charHeight + py;
 		} else {
@@ -3656,7 +3656,7 @@ TableRestrictProc(serial, eventPtr)
      XEvent *eventPtr;
 {
     if ((eventPtr->type == KeyRelease || eventPtr->type == KeyPress) &&
-	((eventPtr->xany.serial-(unsigned int)serial) > 0)) {
+	((eventPtr->xany.serial-PTR2UINT(serial)) > 0)) {
 	return TK_DEFER_EVENT;
     } else {
 	return TK_PROCESS_EVENT;

--- a/pTk/mTk/Tktable/tkTable.h
+++ b/pTk/mTk/Tktable/tkTable.h
@@ -20,6 +20,9 @@
 #include <string.h>
 #include <stdlib.h>
 #include <tk.h>
+#ifdef HAVE_INTTYPES_H /* Defined via tk.h -> tkPort.h -> Lang.h -> tkConfig.h */
+# include <inttypes.h>
+#endif
 #include "tkVMacro.h"
 #include "tkTableversion.h"
 
@@ -50,6 +53,31 @@
 # else
 #  define EXTERN extern
 # endif
+#endif
+
+/*
+ * Macros used to cast between pointers and integers (e.g. when storing an int
+ * in ClientData), on 64-bit architectures they avoid gcc warning about "cast
+ * to/from pointer from/to integer of different size".
+ */
+
+#if !defined(INT2PTR) && !defined(PTR2INT)
+#   if defined(HAVE_INTPTR_T) || defined(intptr_t)
+#	define INT2PTR(p) ((void*)(intptr_t)(p))
+#	define PTR2INT(p) ((int)(intptr_t)(p))
+#   else
+#	define INT2PTR(p) ((void*)(p))
+#	define PTR2INT(p) ((int)(p))
+#   endif
+#endif
+#if !defined(UINT2PTR) && !defined(PTR2UINT)
+#   if defined(HAVE_UINTPTR_T) || defined(uintptr_t)
+#	define UINT2PTR(p) ((void*)(uintptr_t)(p))
+#	define PTR2UINT(p) ((unsigned int)(uintptr_t)(p))
+#   else
+#	define UINT2PTR(p) ((void*)(p))
+#	define PTR2UINT(p) ((unsigned int)(p))
+#   endif
 #endif
 
 #ifdef TCL_STORAGE_CLASS

--- a/pTk/mTk/Tktable/tkTableCmds.c
+++ b/pTk/mTk/Tktable/tkTableCmds.c
@@ -172,8 +172,8 @@ Table_AdjustCmd(ClientData clientData, register Tcl_Interp *interp,
 	/* print out all the preset column widths or row heights */
 	entryPtr = Tcl_FirstHashEntry(hashTablePtr, &search);
 	while (entryPtr != NULL) {
-	    posn = ((int) Tcl_GetHashKey(hashTablePtr, entryPtr)) + offset;
-	    value = (int) Tcl_GetHashValue(entryPtr);
+	    posn = PTR2INT(Tcl_GetHashKey(hashTablePtr, entryPtr)) + offset;
+	    value = PTR2INT(Tcl_GetHashValue(entryPtr));
 	    sprintf(buf1, "%d %d", posn, value);
 	    /* OBJECTIFY */
 	    Tcl_AppendElement(interp, buf1);
@@ -186,10 +186,10 @@ Table_AdjustCmd(ClientData clientData, register Tcl_Interp *interp,
 	}
 	/* no range check is done, why bother? */
 	posn -= offset;
-	entryPtr = Tcl_FindHashEntry(hashTablePtr, (char *) posn);
+	entryPtr = Tcl_FindHashEntry(hashTablePtr, INT2PTR(posn));
 	if (entryPtr != NULL) {
 	    Tcl_SetIntObj(Tcl_GetObjResult(interp),
-			  (int) Tcl_GetHashValue(entryPtr));
+			  PTR2INT(Tcl_GetHashValue(entryPtr)));
 	} else {
 	    Tcl_SetIntObj(Tcl_GetObjResult(interp), widthType ?
 			  tablePtr->defColWidth : tablePtr->defRowHeight);
@@ -206,14 +206,14 @@ Table_AdjustCmd(ClientData clientData, register Tcl_Interp *interp,
 	    posn -= offset;
 	    if (value == -999999) {
 		/* reset that field */
-		entryPtr = Tcl_FindHashEntry(hashTablePtr, (char *) posn);
+		entryPtr = Tcl_FindHashEntry(hashTablePtr, INT2PTR(posn));
 		if (entryPtr != NULL) {
 		    Tcl_DeleteHashEntry(entryPtr);
 		}
 	    } else {
 		entryPtr = Tcl_CreateHashEntry(hashTablePtr,
-					       (char *) posn, &dummy);
-		Tcl_SetHashValue(entryPtr, (ClientData) value);
+					       INT2PTR(posn), &dummy);
+		Tcl_SetHashValue(entryPtr, INT2PTR(value));
 	    }
 	}
 	TableAdjustParams(tablePtr);
@@ -402,10 +402,10 @@ Table_BorderCmd(ClientData clientData, register Tcl_Interp *interp,
 	    if (value < -1) value = -1;
 	    if (value != tablePtr->scanMarkY) {
 		entryPtr = Tcl_CreateHashEntry(tablePtr->rowHeights,
-					       (char *) row, &dummy);
+					       INT2PTR(row), &dummy);
 		/* -value means rowHeight will be interp'd as pixels, not
                    lines */
-		Tcl_SetHashValue(entryPtr, (ClientData) MIN(0,-value));
+		Tcl_SetHashValue(entryPtr, INT2PTR(MIN(0,-value)));
 		tablePtr->scanMarkY = value;
 		key++;
 	    }
@@ -416,10 +416,10 @@ Table_BorderCmd(ClientData clientData, register Tcl_Interp *interp,
 	    if (value < -1) value = -1;
 	    if (value != tablePtr->scanMarkX) {
 		entryPtr = Tcl_CreateHashEntry(tablePtr->colWidths,
-					       (char *) col, &dummy);
+					       INT2PTR(col), &dummy);
 		/* -value means colWidth will be interp'd as pixels, not
                    chars */
-		Tcl_SetHashValue(entryPtr, (ClientData) MIN(0,-value));
+		Tcl_SetHashValue(entryPtr, INT2PTR(MIN(0,-value)));
 		tablePtr->scanMarkX = value;
 		key++;
 	    }
@@ -538,14 +538,14 @@ Table_ClearCmd(ClientData clientData, register Tcl_Interp *interp,
 	     * while size entries are 0-based (real) */
 	    if ((cmdIndex == CLEAR_TAGS || cmdIndex == CLEAR_ALL) &&
 		(entryPtr = Tcl_FindHashEntry(tablePtr->rowStyles,
-					      (char *) row))) {
+					      INT2PTR(row)))) {
 		Tcl_DeleteHashEntry(entryPtr);
 		redraw = 1;
 	    }
 
 	    if ((cmdIndex == CLEAR_SIZES || cmdIndex == CLEAR_ALL) &&
 		(entryPtr = Tcl_FindHashEntry(tablePtr->rowHeights,
-					      (char *) row-tablePtr->rowOffset))) {
+					      INT2PTR(row-tablePtr->rowOffset)))) {
 		Tcl_DeleteHashEntry(entryPtr);
 		redraw = 1;
 	    }
@@ -556,7 +556,7 @@ Table_ClearCmd(ClientData clientData, register Tcl_Interp *interp,
 		if (cmdIndex == CLEAR_TAGS || cmdIndex == CLEAR_ALL) {
 		    if ((row == r1) &&
 			(entryPtr = Tcl_FindHashEntry(tablePtr->colStyles,
-						      (char *) col))) {
+						      INT2PTR(col)))) {
 			Tcl_DeleteHashEntry(entryPtr);
 			redraw = 1;
 		    }
@@ -579,8 +579,8 @@ Table_ClearCmd(ClientData clientData, register Tcl_Interp *interp,
 
 		if ((cmdIndex == CLEAR_SIZES || cmdIndex == CLEAR_ALL) &&
 		    row == r1 &&
-		    (entryPtr = Tcl_FindHashEntry(tablePtr->colWidths, (char *)
-						  col-tablePtr->colOffset))) {
+		    (entryPtr = Tcl_FindHashEntry(tablePtr->colWidths,
+						  INT2PTR(col-tablePtr->colOffset)))) {
 		    Tcl_DeleteHashEntry(entryPtr);
 		    redraw = 1;
 		}

--- a/pTk/mTk/Tktable/tkTableEdit.c
+++ b/pTk/mTk/Tktable/tkTableEdit.c
@@ -606,24 +606,24 @@ TableModifyRC(tablePtr, doRows, flags, tagTblPtr, dimTblPtr,
      * dimensions appropriately
      */
     if (!(flags & HOLD_TAGS)) {
-	entryPtr = Tcl_FindHashEntry(tagTblPtr, (char *)from);
+	entryPtr = Tcl_FindHashEntry(tagTblPtr, INT2PTR(from));
 	if (entryPtr != NULL) {
 	    Tcl_DeleteHashEntry(entryPtr);
 	}
-	entryPtr = Tcl_FindHashEntry(dimTblPtr, (char *)from-offset);
+	entryPtr = Tcl_FindHashEntry(dimTblPtr, INT2PTR(from-offset));
 	if (entryPtr != NULL) {
 	    Tcl_DeleteHashEntry(entryPtr);
 	}
 	if (!outOfBounds) {
-	    entryPtr = Tcl_FindHashEntry(tagTblPtr, (char *)to);
+	    entryPtr = Tcl_FindHashEntry(tagTblPtr, INT2PTR(to));
 	    if (entryPtr != NULL) {
-		newPtr = Tcl_CreateHashEntry(tagTblPtr, (char *)from, &new);
+		newPtr = Tcl_CreateHashEntry(tagTblPtr, INT2PTR(from), &new);
 		Tcl_SetHashValue(newPtr, Tcl_GetHashValue(entryPtr));
 		Tcl_DeleteHashEntry(entryPtr);
 	    }
-	    entryPtr = Tcl_FindHashEntry(dimTblPtr, (char *)to-offset);
+	    entryPtr = Tcl_FindHashEntry(dimTblPtr, INT2PTR(to-offset));
 	    if (entryPtr != NULL) {
-		newPtr = Tcl_CreateHashEntry(dimTblPtr, (char *)from-offset,
+		newPtr = Tcl_CreateHashEntry(dimTblPtr, INT2PTR(from-offset),
 			&new);
 		Tcl_SetHashValue(newPtr, Tcl_GetHashValue(entryPtr));
 		Tcl_DeleteHashEntry(entryPtr);

--- a/pTk/mTk/Tktable/tkTableTag.c
+++ b/pTk/mTk/Tktable/tkTableTag.c
@@ -570,7 +570,7 @@ FindRowColTag(Table *tablePtr, int cell, int mode)
     TableTag *tagPtr = NULL;
     /* kill(0,2); */
     entryPtr = Tcl_FindHashEntry((mode == ROW) ? tablePtr->rowStyles
-				 : tablePtr->colStyles, (char *) cell);
+				 : tablePtr->colStyles, INT2PTR(cell));
     if (entryPtr == NULL) {
 	LangCallback *cmd = (mode == ROW) ? tablePtr->rowTagCmd : tablePtr->colTagCmd;
 	if (cmd) {
@@ -867,7 +867,7 @@ Table_TagCmd(ClientData clientData, register Tcl_Interp *interp,
 				Tcl_GetHashKey(hashTblPtr, scanPtr));
 			value = forRows ? row : col;
 			entryPtr = Tcl_CreateHashEntry(cacheTblPtr,
-				(char *)value, &newEntry);
+				INT2PTR(value), &newEntry);
 			if (newEntry) {
 			    Tcl_ListObjAppendElement(NULL, resultPtr,
 				    Tcl_NewIntObj(value));
@@ -900,7 +900,7 @@ Table_TagCmd(ClientData clientData, register Tcl_Interp *interp,
 			/* is this the tag pointer on this row */
 			if ((TableTag *) Tcl_GetHashValue(scanPtr) == tagPtr) {
 			    objPtr = Tcl_NewIntObj(
-				(int) Tcl_GetHashKey(hashTblPtr, scanPtr));
+				PTR2INT(Tcl_GetHashKey(hashTblPtr, scanPtr)));
 			    Tcl_ListObjAppendElement(NULL, resultPtr, objPtr);
 			}
 		    }
@@ -922,7 +922,7 @@ Table_TagCmd(ClientData clientData, register Tcl_Interp *interp,
 		    /*
 		     * This is a deletion
 		     */
-		    entryPtr = Tcl_FindHashEntry(hashTblPtr, (char *)value);
+		    entryPtr = Tcl_FindHashEntry(hashTblPtr, INT2PTR(value));
 		    if (entryPtr != NULL) {
 			Tcl_DeleteHashEntry(entryPtr);
 			refresh = 1;
@@ -933,7 +933,7 @@ Table_TagCmd(ClientData clientData, register Tcl_Interp *interp,
 		     * Tag structure if it wasn't the same as an existing one
 		     */
 		    entryPtr = Tcl_CreateHashEntry(hashTblPtr,
-			    (char *) value, &newEntry);
+			    INT2PTR(value), &newEntry);
 		    if (newEntry || (tagPtr !=
 			    (TableTag *) Tcl_GetHashValue(entryPtr))) {
 			Tcl_SetHashValue(entryPtr, (ClientData) tagPtr);

--- a/pTk/mTk/Tktable/tkTableUtil.c
+++ b/pTk/mTk/Tktable/tkTableUtil.c
@@ -80,7 +80,7 @@ TableOptionBdSet(clientData, interp, tkwin, value, widgRec, offset)
 {
     char **borderStr;
     int *bordersPtr, *bdPtr;
-    int type	= (int) clientData;
+    int type	= PTR2INT(clientData);
     int result	= TCL_OK;
     int argc;
     Arg *args;
@@ -180,7 +180,7 @@ TableOptionBdGet(clientData, tkwin, widgRec, offset, freeProcPtr)
 					 * information about how to reclaim
 					 * storage for return string. */
 {
-    register int type	= (int) clientData;
+    register int type	= PTR2INT(clientData);
 
     if (type == BD_TABLE) {
 	return LangStringArg( ((TableTag *) (widgRec + offset))->borderStr);


### PR DESCRIPTION
See comments for 7f03179: I figured out how the remaining compiler warnings could be addressed in upstream Tktable (using approaches from recent Tcl/Tk and extensions), but not Tk::TableMatrix. I believe I need a way to determine if `intptr_t` and `uintptr_t` are available, which Config.pm does not appear to provide; since these types are not mandatory for inttypes.h, they may be unavailable even if `$Config{'i_inttypes'}` is defined. It may also be desirable for Perl/Tk to define `HAVE_INTTYPES_H` in tkConfig.h when appropriate.